### PR TITLE
Fix for #326

### DIFF
--- a/markerwithlabel/src/markerwithlabel.js
+++ b/markerwithlabel/src/markerwithlabel.js
@@ -127,10 +127,10 @@ MarkerLabel_.prototype.onAdd = function () {
     me.marker_.setAnimation(null);
   };
 
-  this.getPanes().overlayImage.appendChild(this.labelDiv_);
+  this.getPanes().markerLayer.appendChild(this.labelDiv_);
   // One cross is shared with all markers, so only add it once:
   if (typeof MarkerLabel_.getSharedCross.processed === "undefined") {
-    this.getPanes().overlayImage.appendChild(this.crossDiv_);
+    this.getPanes().markerLayer.appendChild(this.crossDiv_);
     MarkerLabel_.getSharedCross.processed = true;
   }
 


### PR DESCRIPTION
* Added label element to the markerLayer instead of the overlayImage.

It looks like the marker and label elements were created on separate layers, which makes it impossible to set zIndex values which would cause the labels to appear underneath the markers. Appending the label elements to the same layer as the marker elements fixes this problem.

However, I'm not entirely sure if this is a good solution. Maybe there's a reason the labels were added to a separate layer to the markers.