### PR TITLE
Fix marker clusterer images directory

### DIFF
--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -192,7 +192,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @private
  */
 MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ =
-    'https://github.com/googlemaps/v3-utility-library/blob/master/markerclusterer/' +
+    'https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/markerclusterer/' +
     'images/m';
 
 

--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -192,7 +192,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @private
  */
 MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ =
-    'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
+    'https://github.com/googlemaps/v3-utility-library/blob/master/markerclusterer/' +
     'images/m';
 
 


### PR DESCRIPTION
Since the project has moved to github.com, we get 404 when using marker clusterer since it uses the old googlecode URL.