### PR TITLE
Add MarkerWithLabel.dispose() to break a circular reference preventing gc

### DIFF
--- a/markerwithlabel/src/markerwithlabel.js
+++ b/markerwithlabel/src/markerwithlabel.js
@@ -547,3 +547,12 @@ MarkerWithLabel.prototype.setMap = function (theMap) {
   // ... then deal with the label:
   this.label.setMap(theMap);
 };
+
+/**
+ * Removes a circular reference to allow the gc to cleanup
+ */
+MarkerWithLabel.prototype.dispose = function() {
+  this.setMap(null);
+  this.label.marker_ = null;
+  this.label = null;
+};


### PR DESCRIPTION
I have an app that creates and updates markers dynamically. I noticed a memory leak and narrowed it down to a circular reference between the MarkerWithLabel marker and the label. This commit just adds a dispose call that breaks the circular reference to allow garbage collection.