### PR TITLE
Hiding boxes for clustered markers

### DIFF
--- a/infobox/src/infobox.js
+++ b/infobox/src/infobox.js
@@ -116,6 +116,7 @@ function InfoBox(opt_opts) {
   this.div_ = null;
   this.closeListener_ = null;
   this.moveListener_ = null;
+  this.mapListener_ = null;
   this.contextListener_ = null;
   this.eventListeners_ = null;
   this.fixedWidthSet_ = null;
@@ -769,6 +770,10 @@ InfoBox.prototype.open = function (map, anchor) {
     this.moveListener_ = google.maps.event.addListener(anchor, "position_changed", function () {
       me.setPosition(this.getPosition());
     });
+
+    this.mapListener_ = google.maps.event.addListener(anchor, "map_changed", function() {
+      me.setMap(this.map);
+    });    
   }
 
   this.setMap(map);
@@ -807,6 +812,12 @@ InfoBox.prototype.close = function () {
     this.moveListener_ = null;
   }
 
+  if (this.mapListener_) {
+    
+    google.maps.event.removeListener(this.mapListener_);
+    this.mapListener_ = null;    
+  }
+ 
   if (this.contextListener_) {
 
     google.maps.event.removeListener(this.contextListener_);


### PR DESCRIPTION
This makes InfoBox work better with MarkerClusterer, hiding and showing boxes together with markers.