### PR TITLE
Load infobubble close button over https

### DIFF
--- a/infobubble/src/infobubble.js
+++ b/infobubble/src/infobubble.js
@@ -215,7 +215,7 @@ InfoBubble.prototype.buildDom_ = function() {
   close.style['border'] = 0;
   close.style['zIndex'] = this.baseZIndex_ + 1;
   close.style['cursor'] = 'pointer';
-  close.src = 'http://maps.gstatic.com/intl/en_us/mapfiles/iw_close.gif';
+  close.src = 'https://maps.gstatic.com/intl/en_us/mapfiles/iw_close.gif';
 
   var that = this;
   google.maps.event.addDomListener(close, 'click', function() {


### PR DESCRIPTION
Allows infobubble usage on https websites without mixed content warnings

Closes #184 and https://code.google.com/p/google-maps-utility-library-v3/issues/detail?id=184