### PR TITLE
load map and close btn in infobox example over https

### DIFF
--- a/infobox/examples/infobox-basic.html
+++ b/infobox/examples/infobox-basic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?v=3&amp;sensor=false"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3&amp;sensor=false"></script>
 <script type="text/javascript" src="../src/infobox.js"></script>
 <script type="text/javascript">
 	function initialize() {
@@ -38,7 +38,7 @@
 			  ,width: "280px"
 			 }
 			,closeBoxMargin: "10px 2px 2px 2px"
-			,closeBoxURL: "http://www.google.com/intl/en_us/mapfiles/close.gif"
+			,closeBoxURL: "https://www.google.com/intl/en_us/mapfiles/close.gif"
 			,infoBoxClearance: new google.maps.Size(1, 1)
 			,isHidden: false
 			,pane: "floatPane"

--- a/infobox/examples/infobox-label.html
+++ b/infobox/examples/infobox-label.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?v=3&amp;sensor=false"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3&amp;sensor=false"></script>
 <script type="text/javascript" src="../src/infobox.js"></script>
 <script type="text/javascript">
 


### PR DESCRIPTION
Prevent Mixed Content error on [basic](https://htmlpreview.github.io/?https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/infobox/examples/infobox-basic.html) and [label](https://htmlpreview.github.io/?https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/infobox/examples/infobox-label.html) infobox example pages.