### PR TITLE
Fix for `removeMarkers` doesn't remove all markers #360

### DIFF
--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -519,9 +519,12 @@ MarkerClusterer.prototype.removeMarker = function(marker, opt_nodraw) {
  * @param {boolean=} opt_nodraw Optional boolean to force no redraw.
  */
 MarkerClusterer.prototype.removeMarkers = function(markers, opt_nodraw) {
+  // create a local copy of markers if required
+  // (removeMarker_ modifies the getMarkers() array in place)
+  var markersCopy = markers === this.getMarkers() ? markers.slice() : markers;
   var removed = false;
 
-  for (var i = 0, marker; marker = markers[i]; i++) {
+  for (var i = 0, marker; marker = markersCopy[i]; i++) {
     var r = this.removeMarker_(marker);
     removed = removed || r;
   }


### PR DESCRIPTION
This particular problem comes from the pattern
markerClusterer.removeMarkers( markerClusterer.getMarkers() ) as the
underlying mechanism to remove markers performs a splice on the same array
that the remove markers method is working against. This creates a local
copy of the passed in markers array so the above usage pattern works.