### PR TITLE
Change label property name will make markerwithlabel work with markerclusterer

### DIFF
--- a/markerwithlabel/src/markerwithlabel.js
+++ b/markerwithlabel/src/markerwithlabel.js
@@ -523,7 +523,7 @@ function MarkerWithLabel(opt_options) {
   opt_options.handCursor = opt_options.handCursor || "http" + (document.location.protocol === "https:" ? "s" : "") + "://maps.gstatic.com/intl/en_us/mapfiles/closedhand_8_8.cur";
   opt_options.optimized = false; // Optimized rendering is not supported
 
-  this.label = new MarkerLabel_(this, opt_options.crossImage, opt_options.handCursor); // Bind the label to the marker
+  this.markerLabel = new MarkerLabel_(this, opt_options.crossImage, opt_options.handCursor); // Bind the label to the marker
 
   // Call the parent constructor. It calls Marker.setValues to initialize, so all
   // the new parameters are conveniently saved and can be accessed with get/set.
@@ -545,5 +545,5 @@ MarkerWithLabel.prototype.setMap = function (theMap) {
   google.maps.Marker.prototype.setMap.apply(this, arguments);
 
   // ... then deal with the label:
-  this.label.setMap(theMap);
+  this.markerLabel.setMap(theMap);
 };


### PR DESCRIPTION
Changing the name to the markerwithlabel this.label property to any other name, like this.markerLabel, will avoid a crash occurs when this object is inserted into a markerclusterer object and the latter invokes markerwithlabel setMap method. Then a "setMap method doesn't exist" error message is displayed. 
This error occurs when in the JSON definition of the MarkerWithLabel, the label property is set. This overwrites the this.label = MarkerLabel_(...) property set in line 526.
So if in line 526 we assign the MarkerLabel_ to another property name, both property won't collide, this error won't happen and the markerclusterer objects will display beautiful.