### PR TITLE
set a z index on cluster div's for click handling purposes (aka issue #401)

### DIFF
--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -1116,6 +1116,7 @@ ClusterIcon.prototype.draw = function() {
     var pos = this.getPosFromLatLng_(this.center_);
     this.div_.style.top = pos.y + 'px';
     this.div_.style.left = pos.x + 'px';
+    this.div_.style.zIndex = google.maps.Marker.MAX_ZINDEX + 1;
   }
 };
 

--- a/markerclustererplus/src/markerclusterer.js
+++ b/markerclustererplus/src/markerclusterer.js
@@ -219,6 +219,7 @@ ClusterIcon.prototype.draw = function () {
     var pos = this.getPosFromLatLng_(this.center_);
     this.div_.style.top = pos.y + "px";
     this.div_.style.left = pos.x + "px";
+    this.div_.style.zIndex = google.maps.Marker.MAX_ZINDEX + 1;
   }
 };
 


### PR DESCRIPTION
If we have unclustered markers showing close enough to a cluster, clicking on the cluster executes the underlying marker's click handler because of marker's higher zIndex