### PR TITLE
Fix error where maxZoom is called on undefined object

### DIFF
--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -408,6 +408,9 @@ MarkerClusterer.prototype.getCalculator = function() {
 MarkerClusterer.prototype.addMarkers = function(markers, opt_nodraw) {
   if (markers.length) {
     for (var i = 0, marker; marker = markers[i]; i++) {
+      //  Don't display markers with 0,0 Lat|Lng
+      if (!marker.position.lat() && !marker.position.lng())
+        continue;
       this.pushMarkerTo_(marker);
     }
   } else if (Object.keys(markers).length) {

--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -164,11 +164,12 @@ function MarkerClusterer(map, opt_markers, opt_options) {
   // Add the map event listeners
   var that = this;
   google.maps.event.addListener(this.map_, 'zoom_changed', function() {
+    var mapType = that.map_.mapTypes[that.map_.getMapTypeId()];
     // Determines map type and prevent illegal zoom levels
     var zoom = that.map_.getZoom();
     var minZoom = that.map_.minZoom || 0;
     var maxZoom = Math.min(that.map_.maxZoom || 100,
-                         that.map_.mapTypes[that.map_.getMapTypeId()].maxZoom);
+      mapType ? mapType.maxZoom : 100);
     zoom = Math.min(Math.max(zoom,minZoom),maxZoom);
 
     if (that.prevZoom_ != zoom) {


### PR DESCRIPTION
Fixes an error that occurs when the map setZoom is called before markers have been placed. 

`that.map_.mapTypes[that.map_.getMapTypeId()]` is undefined, and throws error when `.maxZoom` is called.

<img width="742" alt="screen shot 2018-04-04 at 12 08 27 pm" src="https://user-images.githubusercontent.com/12739575/38284903-f4dbe7ac-3800-11e8-98e0-5511631ec3fa.png">
