### PR TITLE
Update the content of the marker only if it has changed.

### DIFF
--- a/markerwithlabel/src/markerwithlabel.js
+++ b/markerwithlabel/src/markerwithlabel.js
@@ -370,15 +370,19 @@ MarkerLabel_.prototype.draw = function () {
  */
 MarkerLabel_.prototype.setContent = function () {
   var content = this.marker_.get("labelContent");
-  if (typeof content.nodeType === "undefined") {
-    this.labelDiv_.innerHTML = content;
-    this.eventDiv_.innerHTML = this.labelDiv_.innerHTML;
-  } else {
-    this.labelDiv_.innerHTML = ""; // Remove current content
-    this.labelDiv_.appendChild(content);
-    content = content.cloneNode(true);
-    this.eventDiv_.innerHTML = ""; // Remove current content
-    this.eventDiv_.appendChild(content);
+  var previousContent = this.marker_._previousContent;
+  if(previousContent !== content){
+    this.marker_._previousContent = content;
+    if (typeof content.nodeType === "undefined") {
+      this.labelDiv_.innerHTML = content;
+      this.eventDiv_.innerHTML = this.labelDiv_.innerHTML;
+    } else {
+      this.labelDiv_.innerHTML = ""; // Remove current content
+      this.labelDiv_.appendChild(content);
+      content = content.cloneNode(true);
+      this.eventDiv_.innerHTML = ""; // Remove current content
+      this.eventDiv_.appendChild(content);
+    }
   }
 };
 


### PR DESCRIPTION
This fixes #412 by keeping track of the latest content used in the marker and comparing against it when using the `setContent` method to avoid unnecessary updates.