### PR TITLE
Replace native objects re-assignment with simple ifs in markerclusterer

### DIFF
--- a/markerclusterer/package.json
+++ b/markerclusterer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/markerclusterer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Google Inc.",
   "description": "The library creates and manages per-zoom-level clusters for large amounts of markers.",
   "main": "src/markerclusterer.js",

--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -1259,62 +1259,65 @@ ClusterIcon.prototype.createCss = function(pos) {
 // Export Symbols for Closure
 // If you are not going to compile with closure then you can remove the
 // code below.
-var window = window || {};
-window['MarkerClusterer'] = MarkerClusterer;
-MarkerClusterer.prototype['addMarker'] = MarkerClusterer.prototype.addMarker;
-MarkerClusterer.prototype['addMarkers'] = MarkerClusterer.prototype.addMarkers;
-MarkerClusterer.prototype['clearMarkers'] =
-    MarkerClusterer.prototype.clearMarkers;
-MarkerClusterer.prototype['fitMapToMarkers'] =
-    MarkerClusterer.prototype.fitMapToMarkers;
-MarkerClusterer.prototype['getCalculator'] =
-    MarkerClusterer.prototype.getCalculator;
-MarkerClusterer.prototype['getGridSize'] =
-    MarkerClusterer.prototype.getGridSize;
-MarkerClusterer.prototype['getExtendedBounds'] =
-    MarkerClusterer.prototype.getExtendedBounds;
-MarkerClusterer.prototype['getMap'] = MarkerClusterer.prototype.getMap;
-MarkerClusterer.prototype['getMarkers'] = MarkerClusterer.prototype.getMarkers;
-MarkerClusterer.prototype['getMaxZoom'] = MarkerClusterer.prototype.getMaxZoom;
-MarkerClusterer.prototype['getStyles'] = MarkerClusterer.prototype.getStyles;
-MarkerClusterer.prototype['getTotalClusters'] =
-    MarkerClusterer.prototype.getTotalClusters;
-MarkerClusterer.prototype['getTotalMarkers'] =
-    MarkerClusterer.prototype.getTotalMarkers;
-MarkerClusterer.prototype['redraw'] = MarkerClusterer.prototype.redraw;
-MarkerClusterer.prototype['removeMarker'] =
-    MarkerClusterer.prototype.removeMarker;
-MarkerClusterer.prototype['removeMarkers'] =
-    MarkerClusterer.prototype.removeMarkers;
-MarkerClusterer.prototype['resetViewport'] =
-    MarkerClusterer.prototype.resetViewport;
-MarkerClusterer.prototype['repaint'] =
-    MarkerClusterer.prototype.repaint;
-MarkerClusterer.prototype['setCalculator'] =
-    MarkerClusterer.prototype.setCalculator;
-MarkerClusterer.prototype['setGridSize'] =
-    MarkerClusterer.prototype.setGridSize;
-MarkerClusterer.prototype['setMaxZoom'] =
-    MarkerClusterer.prototype.setMaxZoom;
-MarkerClusterer.prototype['onAdd'] = MarkerClusterer.prototype.onAdd;
-MarkerClusterer.prototype['draw'] = MarkerClusterer.prototype.draw;
+if (typeof window !== 'undefined') {
+  window['MarkerClusterer'] = MarkerClusterer;
+  MarkerClusterer.prototype['addMarker'] = MarkerClusterer.prototype.addMarker;
+  MarkerClusterer.prototype['addMarkers'] = MarkerClusterer.prototype.addMarkers;
+  MarkerClusterer.prototype['clearMarkers'] =
+      MarkerClusterer.prototype.clearMarkers;
+  MarkerClusterer.prototype['fitMapToMarkers'] =
+      MarkerClusterer.prototype.fitMapToMarkers;
+  MarkerClusterer.prototype['getCalculator'] =
+      MarkerClusterer.prototype.getCalculator;
+  MarkerClusterer.prototype['getGridSize'] =
+      MarkerClusterer.prototype.getGridSize;
+  MarkerClusterer.prototype['getExtendedBounds'] =
+      MarkerClusterer.prototype.getExtendedBounds;
+  MarkerClusterer.prototype['getMap'] = MarkerClusterer.prototype.getMap;
+  MarkerClusterer.prototype['getMarkers'] = MarkerClusterer.prototype.getMarkers;
+  MarkerClusterer.prototype['getMaxZoom'] = MarkerClusterer.prototype.getMaxZoom;
+  MarkerClusterer.prototype['getStyles'] = MarkerClusterer.prototype.getStyles;
+  MarkerClusterer.prototype['getTotalClusters'] =
+      MarkerClusterer.prototype.getTotalClusters;
+  MarkerClusterer.prototype['getTotalMarkers'] =
+      MarkerClusterer.prototype.getTotalMarkers;
+  MarkerClusterer.prototype['redraw'] = MarkerClusterer.prototype.redraw;
+  MarkerClusterer.prototype['removeMarker'] =
+      MarkerClusterer.prototype.removeMarker;
+  MarkerClusterer.prototype['removeMarkers'] =
+      MarkerClusterer.prototype.removeMarkers;
+  MarkerClusterer.prototype['resetViewport'] =
+      MarkerClusterer.prototype.resetViewport;
+  MarkerClusterer.prototype['repaint'] =
+      MarkerClusterer.prototype.repaint;
+  MarkerClusterer.prototype['setCalculator'] =
+      MarkerClusterer.prototype.setCalculator;
+  MarkerClusterer.prototype['setGridSize'] =
+      MarkerClusterer.prototype.setGridSize;
+  MarkerClusterer.prototype['setMaxZoom'] =
+      MarkerClusterer.prototype.setMaxZoom;
+  MarkerClusterer.prototype['onAdd'] = MarkerClusterer.prototype.onAdd;
+  MarkerClusterer.prototype['draw'] = MarkerClusterer.prototype.draw;
 
-Cluster.prototype['getCenter'] = Cluster.prototype.getCenter;
-Cluster.prototype['getSize'] = Cluster.prototype.getSize;
-Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
+  Cluster.prototype['getCenter'] = Cluster.prototype.getCenter;
+  Cluster.prototype['getSize'] = Cluster.prototype.getSize;
+  Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
 
-ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
-ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
-ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
+  ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
+  ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
+  ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
+}
 
-Object.keys = Object.keys || function(o) {
-    var result = [];
-    for(var name in o) {
-        if (o.hasOwnProperty(name))
-          result.push(name);
-    }
-    return result;
-};
+if (typeof Object.keys !== 'function') {
+  Object.keys = function(o) {
+      var result = [];
+      for(var name in o) {
+          if (o.hasOwnProperty(name))
+            result.push(name);
+      }
+      return result;
+  };
+}
 
 if (typeof module == 'object') {
   module.exports = MarkerClusterer;

--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -1261,52 +1261,52 @@ ClusterIcon.prototype.createCss = function(pos) {
 // code below.
 if (typeof window !== 'undefined') {
   window['MarkerClusterer'] = MarkerClusterer;
-  MarkerClusterer.prototype['addMarker'] = MarkerClusterer.prototype.addMarker;
-  MarkerClusterer.prototype['addMarkers'] = MarkerClusterer.prototype.addMarkers;
-  MarkerClusterer.prototype['clearMarkers'] =
-      MarkerClusterer.prototype.clearMarkers;
-  MarkerClusterer.prototype['fitMapToMarkers'] =
-      MarkerClusterer.prototype.fitMapToMarkers;
-  MarkerClusterer.prototype['getCalculator'] =
-      MarkerClusterer.prototype.getCalculator;
-  MarkerClusterer.prototype['getGridSize'] =
-      MarkerClusterer.prototype.getGridSize;
-  MarkerClusterer.prototype['getExtendedBounds'] =
-      MarkerClusterer.prototype.getExtendedBounds;
-  MarkerClusterer.prototype['getMap'] = MarkerClusterer.prototype.getMap;
-  MarkerClusterer.prototype['getMarkers'] = MarkerClusterer.prototype.getMarkers;
-  MarkerClusterer.prototype['getMaxZoom'] = MarkerClusterer.prototype.getMaxZoom;
-  MarkerClusterer.prototype['getStyles'] = MarkerClusterer.prototype.getStyles;
-  MarkerClusterer.prototype['getTotalClusters'] =
-      MarkerClusterer.prototype.getTotalClusters;
-  MarkerClusterer.prototype['getTotalMarkers'] =
-      MarkerClusterer.prototype.getTotalMarkers;
-  MarkerClusterer.prototype['redraw'] = MarkerClusterer.prototype.redraw;
-  MarkerClusterer.prototype['removeMarker'] =
-      MarkerClusterer.prototype.removeMarker;
-  MarkerClusterer.prototype['removeMarkers'] =
-      MarkerClusterer.prototype.removeMarkers;
-  MarkerClusterer.prototype['resetViewport'] =
-      MarkerClusterer.prototype.resetViewport;
-  MarkerClusterer.prototype['repaint'] =
-      MarkerClusterer.prototype.repaint;
-  MarkerClusterer.prototype['setCalculator'] =
-      MarkerClusterer.prototype.setCalculator;
-  MarkerClusterer.prototype['setGridSize'] =
-      MarkerClusterer.prototype.setGridSize;
-  MarkerClusterer.prototype['setMaxZoom'] =
-      MarkerClusterer.prototype.setMaxZoom;
-  MarkerClusterer.prototype['onAdd'] = MarkerClusterer.prototype.onAdd;
-  MarkerClusterer.prototype['draw'] = MarkerClusterer.prototype.draw;
-
-  Cluster.prototype['getCenter'] = Cluster.prototype.getCenter;
-  Cluster.prototype['getSize'] = Cluster.prototype.getSize;
-  Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
-
-  ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
-  ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
-  ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
 }
+MarkerClusterer.prototype['addMarker'] = MarkerClusterer.prototype.addMarker;
+MarkerClusterer.prototype['addMarkers'] = MarkerClusterer.prototype.addMarkers;
+MarkerClusterer.prototype['clearMarkers'] =
+    MarkerClusterer.prototype.clearMarkers;
+MarkerClusterer.prototype['fitMapToMarkers'] =
+    MarkerClusterer.prototype.fitMapToMarkers;
+MarkerClusterer.prototype['getCalculator'] =
+    MarkerClusterer.prototype.getCalculator;
+MarkerClusterer.prototype['getGridSize'] =
+    MarkerClusterer.prototype.getGridSize;
+MarkerClusterer.prototype['getExtendedBounds'] =
+    MarkerClusterer.prototype.getExtendedBounds;
+MarkerClusterer.prototype['getMap'] = MarkerClusterer.prototype.getMap;
+MarkerClusterer.prototype['getMarkers'] = MarkerClusterer.prototype.getMarkers;
+MarkerClusterer.prototype['getMaxZoom'] = MarkerClusterer.prototype.getMaxZoom;
+MarkerClusterer.prototype['getStyles'] = MarkerClusterer.prototype.getStyles;
+MarkerClusterer.prototype['getTotalClusters'] =
+    MarkerClusterer.prototype.getTotalClusters;
+MarkerClusterer.prototype['getTotalMarkers'] =
+    MarkerClusterer.prototype.getTotalMarkers;
+MarkerClusterer.prototype['redraw'] = MarkerClusterer.prototype.redraw;
+MarkerClusterer.prototype['removeMarker'] =
+    MarkerClusterer.prototype.removeMarker;
+MarkerClusterer.prototype['removeMarkers'] =
+    MarkerClusterer.prototype.removeMarkers;
+MarkerClusterer.prototype['resetViewport'] =
+    MarkerClusterer.prototype.resetViewport;
+MarkerClusterer.prototype['repaint'] =
+    MarkerClusterer.prototype.repaint;
+MarkerClusterer.prototype['setCalculator'] =
+    MarkerClusterer.prototype.setCalculator;
+MarkerClusterer.prototype['setGridSize'] =
+    MarkerClusterer.prototype.setGridSize;
+MarkerClusterer.prototype['setMaxZoom'] =
+    MarkerClusterer.prototype.setMaxZoom;
+MarkerClusterer.prototype['onAdd'] = MarkerClusterer.prototype.onAdd;
+MarkerClusterer.prototype['draw'] = MarkerClusterer.prototype.draw;
+
+Cluster.prototype['getCenter'] = Cluster.prototype.getCenter;
+Cluster.prototype['getSize'] = Cluster.prototype.getSize;
+Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
+
+ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
+ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
+ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
 
 if (typeof Object.keys !== 'function') {
   Object.keys = function(o) {


### PR DESCRIPTION
Hi, I found an issue with `markerclusterer` package.

Sometimes you reassign native objects like `window` with itself or empty object to make sure that your code will work even in headless browsers. Normally this approach works fine, but if you try to minimize it, the code like
```var window = window || {};```
turns into
```var a = a || {};```
and it breaks.

The solution I propose is more straightforward: it simply checks if corresponding native objects exist. Basically it does the same, but is "minifiable".