### PR TITLE
fixed typo

### DIFF
--- a/styledmarker/docs/reference.html
+++ b/styledmarker/docs/reference.html
@@ -123,7 +123,7 @@
             </tr>
             <tr class="even">
               <td><code>defaults</code></td>
-              <td><code><a href="#BUBBLE">MARKER</a></code></td>
+              <td><code><a href="#BUBBLE">BUBBLE</a></code></td>
               <td>Resembles a small <code>InfoWindow</code> with a single line of text. Can alter color or have a string of text placed in it.</td>
             </tr>
           </tbody>


### PR DESCRIPTION
href leads to BUBBLE, but text showed "MARKER"