### PR TITLE
Update markerclusterer.js: recentering the map after click on cluster

### DIFF
--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -1059,14 +1059,16 @@ function ClusterIcon(cluster, styles, opt_padding) {
  * Triggers the clusterclick event and zoom's if the option is set.
  */
 ClusterIcon.prototype.triggerClusterClick = function() {
-  var markerClusterer = this.cluster_.getMarkerClusterer();
+  var clusterBounds   = this.cluster_.getBounds();
+  var markerClusterer = this.cluster_.getMarkerClusterer();  
 
   // Trigger the clusterclick event.
   google.maps.event.trigger(markerClusterer.map_, 'clusterclick', this.cluster_);
 
   if (markerClusterer.isZoomOnClick()) {
     // Zoom into the cluster.
-    this.map_.fitBounds(this.cluster_.getBounds());
+    this.map_.fitBounds(clusterBounds);
+    this.map_.setCenter(clusterBounds.getCenter());
   }
 };
 


### PR DESCRIPTION
Fixes the bug when map is sometimes doesn't proper recenter. 
Center map to the the bounds of all markers inside a cluster.