### PR TITLE
Prevent error: `window.setTimeout is not a function`

### DIFF
--- a/markerclusterer/src/markerclusterer.js
+++ b/markerclusterer/src/markerclusterer.js
@@ -709,7 +709,7 @@ MarkerClusterer.prototype.repaint = function() {
 
   // Remove the old clusters.
   // Do it in a timeout so the other clusters have been drawn first.
-  window.setTimeout(function() {
+  setTimeout(function() {
     for (var i = 0, cluster; cluster = oldClusters[i]; i++) {
       cluster.remove();
     }


### PR DESCRIPTION
`window` may be set to `{}`. ([markerclusterer.js#L1264](https://github.com/ipcjs/v3-utility-library/blob/f38c127ab0d65b01cc26c317cdf39da5975bac79/markerclusterer/src/markerclusterer.js#L1264))