### PR TITLE
commonJs is more friendly to Typescript.

### DIFF
--- a/packages/markerclusterer/package.json
+++ b/packages/markerclusterer/package.json
@@ -22,7 +22,7 @@
     "dist/*",
     "src/*"
   ],
-  "main": "dist/markerclusterer.umd.js",
+  "main": "dist/markerclusterer.common.js",
   "unpkg": "dist/markerclusterer.min.js",
   "module": "dist/markerclusterer.esm.js",
   "scripts": {

--- a/packages/markerclusterer/rollup.config.js
+++ b/packages/markerclusterer/rollup.config.js
@@ -27,5 +27,12 @@ export default [
             file: 'dist/markerclusterer.esm.js',
             format: 'esm'
         }
-    }
+    },
+    {
+        input: 'src/markerclusterer.js',
+        output: {
+            file: 'dist/markerclusterer.common.js',
+            format: 'cjs'
+        }
+    },
 ];


### PR DESCRIPTION
Typescript resolve module through the `main` field in `package.json`. (see: https://github.com/microsoft/TypeScript/issues/21423)

When `main` is set to `xxx.umd.js`, typescript reports ts2386 error. set to `xxx.common.js` to avoid this problem.

![ScreenClip  17](https://user-images.githubusercontent.com/4396864/66381565-2b542800-e9ec-11e9-80d4-494b284de662.png)
