### PR TITLE
Added typing generation to Markerclustererplus

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "ts-jest": "^24.1.0",
     "typedoc": "^0.15.0",
     "typedoc-plugin-lerna-packages": "^0.2.1",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   }
 }

--- a/packages/markerclustererplus/package.json
+++ b/packages/markerclustererplus/package.json
@@ -26,6 +26,7 @@
   "main": "dist/markerclustererplus.umd.js",
   "unpkg": "dist/markerclustererplus.min.js",
   "module": "dist/markerclustererplus.esm.js",
+  "types": "dist/markerclusterer.d.ts",
   "scripts": {
     "format": "sort-package-json && prettier *.json *.js src/* examples/* --write",
     "lint": "eslint src/*",

--- a/packages/markerclustererplus/rollup.config.js
+++ b/packages/markerclustererplus/rollup.config.js
@@ -1,4 +1,5 @@
 import { terser } from "rollup-plugin-terser";
+import typescript from "rollup-plugin-typescript2";
 
 export default [
   {
@@ -21,6 +22,10 @@ export default [
   },
   {
     input: "src/markerclusterer.js",
+    // Adding in a TS definition file. Should not impact the generation of the ESM package
+    plugins: [typescript({
+      tsconfig: "tsconfig.json",
+    })],
     output: {
       file: "dist/markerclustererplus.esm.js",
       format: "esm"

--- a/packages/markerclustererplus/tsconfig.json
+++ b/packages/markerclustererplus/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [
+    "src/markerclusterer.js"
+  ],
+  "compilerOptions": {
+    "noEmit": false,
+    "allowJs": true,
+    "declaration": true,
+    "declarationDir": "typings",
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
Per TS3.7 updates (and enabled by #552), we're now able to generate a `.d.ts` file from the JSDoc comments. This PR adds in typings to the Markerclustererplus distributed package