### PR TITLE
fix: remove old documentation links

### DIFF
--- a/packages/markerclusterer/README.md
+++ b/packages/markerclusterer/README.md
@@ -9,8 +9,6 @@ Creates and manages per-zoom-level clusters for large amounts of markers.
 
 Available via NPM as the package `@google/markerclusterer`
 
-[Read more][more]
-
 ## Support
 
 This library is community supported. We're comfortable enough with the stability and features of
@@ -21,4 +19,3 @@ contribute, please read [How to Contribute][contrib].
 
 [issues]: https://github.com/googlemaps/v3-utility-library/issues
 [contrib]: https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerclusterer/CONTRIB.md
-[more]: https://googlemaps.github.io/js-marker-clusterer/docs/reference.html

--- a/packages/markerclustererplus/README.md
+++ b/packages/markerclustererplus/README.md
@@ -11,8 +11,6 @@ It is based on the V3 MarkerClusterer port by Luke Mahe. MarkerClustererPlus was
 
 Available via NPM as the package `@google/markerclustererplus`
 
-[Read more][more]
-
 ## Support
 
 This library is community supported. We're comfortable enough with the stability and features of
@@ -23,4 +21,3 @@ contribute, please read [How to Contribute][contrib].
 
 [issues]: https://github.com/googlemaps/v3-utility-library/issues
 [contrib]: https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerclustererplus/CONTRIB.md
-[more]: http://htmlpreview.github.io/?https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerclustererplus/docs/reference.html

--- a/packages/markermanager/README.md
+++ b/packages/markermanager/README.md
@@ -9,7 +9,6 @@ Marker manager is an interface between the map and the user, designed to manage 
 
 The MarkerManager places its markers onto a grid, similar to the map tiles. When the user moves the viewport, it computes which grid cells have entered or left the viewport, and shows or hides all the markers in those cells. (If the users scrolls the viewport beyond the markers that are loaded, no markers will be visible until the EVENT_moveend triggers an update.) In practical consequences, this allows 10,000 markers to be distributed over a large area, and as long as only 100-200 are visible in any given viewport, the user will see good performance corresponding to the 100 visible markers, rather than poor performance corresponding to the total 10,000 markers. Note that some code is optimized for speed over space, with the goal of accommodating thousands of markers.
 
-[Read more][more]
 
 ## Support
 
@@ -21,4 +20,3 @@ contribute, please read [How to Contribute][contrib].
 
 [issues]: https://github.com/googlemaps/v3-utility-library/issues
 [contrib]: https://github.com/googlemaps/v3-utility-library/blob/master/packages/markermanager/CONTRIB.md
-[more]: http://htmlpreview.github.io/?https://github.com/googlemaps/v3-utility-library/blob/master/packages/markermanager/docs/reference.html

--- a/packages/markerwithlabel/README.md
+++ b/packages/markerwithlabel/README.md
@@ -12,7 +12,6 @@ If you drag a marker by its label, you can cancel the drag and return the marker
 
 Available via NPM as the package `@google/markerwithlabel`
 
-[Read more][more]
 
 ## Support
 
@@ -24,4 +23,3 @@ contribute, please read [How to Contribute][contrib].
 
 [issues]: https://github.com/googlemaps/v3-utility-library/issues
 [contrib]: https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerwithlabel/CONTRIB.md
-[more]: http://htmlpreview.github.io/?https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerwithlabel/docs/reference.html


### PR DESCRIPTION
see #571 #572 #573 for using typedoc

closes #570 