### PR TITLE
Fix typo when getting z-index from MarkerClusterer

### DIFF
--- a/packages/markerclusterer/src/markerclusterer.js
+++ b/packages/markerclusterer/src/markerclusterer.js
@@ -1197,7 +1197,7 @@ class ClusterIcon {
    */
   createCss(pos) {
     var style = [];
-    style.push("z-index:" + this.markerClusterer_.getZIndex() + ";");
+    style.push("z-index:" + this.cluster_.markerClusterer_.getZIndex() + ";");
     style.push("background-image:url(" + this.url_ + ");");
     var backgroundPosition = this.backgroundPosition_
       ? this.backgroundPosition_

--- a/packages/markerclustererplus/src/markerclusterer.js
+++ b/packages/markerclustererplus/src/markerclusterer.js
@@ -383,7 +383,7 @@ class ClusterIcon {
    */
   createCss(pos) {
     var style = [];
-    style.push("z-index: " + this.markerClusterer_.getZIndex() + ";");
+    style.push("z-index: " + this.cluster_.markerClusterer_.getZIndex() + ";");
     style.push("cursor: pointer;");
     style.push(
       "position: absolute; top: " + pos.y + "px; left: " + pos.x + "px;"


### PR DESCRIPTION
This bug was introduced in #569.