### PR TITLE
chore: update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.6",
-    "@types/googlemaps": "^3.37.7",
+    "@types/googlemaps": "^3.38.1",
     "@types/jest": "^24.0.19",
     "@typescript-eslint/eslint-plugin": "^2.4.0",
     "@typescript-eslint/parser": "^2.0.0",
@@ -39,7 +39,7 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-terser": "^5.1.2",
+    "rollup-plugin-terser": "^5.1.3",
     "rollup-plugin-typescript2": "^0.24.3",
     "sort-package-json": "^1.22.1",
     "ts-jest": "^24.1.0",


### PR DESCRIPTION
@types/googlemaps 3.38.1 has `google.maps.version` needed for #590. thanks @bamnet