### PR TITLE
fix(markerclustererplus): re-render icons on end of clustering cycle

### DIFF
--- a/packages/markerclustererplus/src/cluster.ts
+++ b/packages/markerclustererplus/src/cluster.ts
@@ -170,7 +170,6 @@ export class Cluster {
       marker.setMap(null);
     }
 
-    this.updateIcon_();
     return true;
   }
 
@@ -196,7 +195,7 @@ export class Cluster {
   /**
    * Updates the cluster icon.
    */
-  private updateIcon_(): void {
+  public updateIcon(): void {
     const mCount = this.markers_.length;
     const mz = this.markerClusterer_.getMaxZoom();
 

--- a/packages/markerclustererplus/src/markerclusterer.ts
+++ b/packages/markerclustererplus/src/markerclusterer.ts
@@ -1130,6 +1130,10 @@ export class MarkerClusterer extends OverlayViewSafe {
     } else {
       delete this.timerRefStatic;
       google.maps.event.trigger(this, "clusteringend", this);
+
+      for (let i = 0; i < this.clusters_.length; i++) {
+        this.clusters_[i].updateIcon();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/googlemaps/v3-utility-library/issues/605
