### PR TITLE
docs: changelog fix formatting and link example

### DIFF
--- a/packages/markerclustererplus/CHANGELOG.md
+++ b/packages/markerclustererplus/CHANGELOG.md
@@ -32,7 +32,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **markerclustererplus:** When `MarkerClustererOptions.style` is passed to constructor,
 it completely replaces defaults and does not extend defaults as before.
 
-  If you want to override only some values, but not replace whole styles use `MarkerClusterer.withDefaultStyle()` function (see [`examples/events_example.html`](https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerclustererplus/examples/events_example.html) for usage examples).
+  If you want to override only some values, but not replace whole styles use `MarkerClusterer.withDefaultStyle()` function (see [`examples/advanced_example.html`](https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerclustererplus/examples/advanced_example.html) for usage examples).
 
   Overriding whole styles is useful when `ClusterIconStyle.className` is used and styling
   is performed using external CSS styles (which is recommended way).

--- a/packages/markerclustererplus/CHANGELOG.md
+++ b/packages/markerclustererplus/CHANGELOG.md
@@ -32,10 +32,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **markerclustererplus:** When `MarkerClustererOptions.style` is passed to constructor,
 it completely replaces defaults and does not extend defaults as before.
 
-If you want to override only some values, but not replace whole styles use `MarkerClusterer.withDefaultStyle()` function (see `examples/events_example.html` for usage examples).
+  If you want to override only some values, but not replace whole styles use `MarkerClusterer.withDefaultStyle()` function (see [`examples/events_example.html`](https://github.com/googlemaps/v3-utility-library/blob/master/packages/markerclustererplus/examples/events_example.html) for usage examples).
 
-Overriding whole styles is useful when `ClusterIconStyle.className` is used and styling
-is performed using external CSS styles (which is recommended way).
+  Overriding whole styles is useful when `ClusterIconStyle.className` is used and styling
+  is performed using external CSS styles (which is recommended way).
 
 
 


### PR DESCRIPTION
Link markerclustererplus `advanced_example.html`