### PR TITLE
fix: missing `getClickableIcons` in class `_Map` [@googlemaps/jest-mocks]

### DIFF
--- a/packages/jest-mocks/src/map.ts
+++ b/packages/jest-mocks/src/map.ts
@@ -45,6 +45,7 @@ export class Map_ extends MVCObject implements google.maps.Map {
     .mockImplementation(
       (): google.maps.LatLng => new LatLng({ lat: 0, lng: 0 })
     );
+  getClickableIcons = jest.fn().mockImplementation((): boolean => false);
   getDiv = jest.fn().mockImplementation(
     (): Element => {
       return (jest.fn() as unknown) as Element;


### PR DESCRIPTION
Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #680 
